### PR TITLE
fix: syntax error in sql query

### DIFF
--- a/notes_app/database/db_helper.py
+++ b/notes_app/database/db_helper.py
@@ -26,16 +26,15 @@ class SQLiteConnection:
     def create_note(self, note):
         try:
             cursor = self.connection.cursor()
-            sql = """INSERT INTO notes(description) VALUES (?) RETURNING id;"""
+            sql = """INSERT INTO notes(description) VALUES (?);"""
             cursor.execute(sql, (note.description,))
-            note_id = cursor.fetchone()[0]
             self.connection.commit()
-            cursor.close()
             logging.info(f"Created note with id: {note.id}")
-            return note_id
+            return cursor.lastrowid
         except Exception as e:
             logging.error(e)
             self.connection.rollback()
+        finally:
             cursor.close()
 
     def update_note(self, note):


### PR DESCRIPTION
We can retrieve the row id of the insert statement after the SQL statement is executed.