### PR TITLE
Add module 'Werkzeug' in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask==2.2.2
 psycopg2-binary==2.9.6
 requests==2.28.1
 ddtrace
+Werkzeug==2.2.2


### PR DESCRIPTION
**What this PR does / why we need it:**

- Adding module `Werkzeug` with version `2.2.2`

## Problem
- As the `Werkzeug 3.0.0` was [released](https://werkzeug.palletsprojects.com/en/3.0.x/changes/#version-3-0-0) and Flask doesn't specify the dependency correctly, we get the following error when running the apps

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/calendar_app/app.py", line 8, in <module>
    from flask import Flask
  File "/usr/local/lib/python3.12/site-packages/wrapt/importer.py", line 182, in _exec_module self.loader.exec_module(module)
  File "/usr/local/lib/python3.12/site-packages/ddtrace/internal/module.py", line 220, in _exec_module
    self.loader.exec_module(module)
  File "/usr/local/lib/python3.12/site-packages/flask/__init__.py", line 5, in <from .app import Flask as Flask
  File "/usr/local/lib/python3.12/site-packages/ddtrace/internal/module.py", line 220, in _exec_module self.loader.exec_module(module)
  File "/usr/local/lib/python3.12/site-packages/flask/app.py", line 30, in <module>
  from werkzeug.urls import url_quote
  ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.12/site-packages/werkzeug/urls.py). Did you mean: 'unquote'?
```

## Solution
- Added specific version `Werkzeug==2.2.2` in the requirements.txt file in order to fix the issue